### PR TITLE
Dev grouping

### DIFF
--- a/src/funcs/ping.go
+++ b/src/funcs/ping.go
@@ -36,7 +36,11 @@ func StartPing(t g.Target, wg *sync.WaitGroup) {
 		duringtime := time.Now().UnixNano() - starttime
 		time.Sleep(time.Duration(3000*1000000-duringtime) * time.Nanosecond)
 	}
-	stat.AvgDelay = stat.AvgDelay / float64(stat.RevcPk)
+	if stat.RevcPk > 0 {
+		stat.AvgDelay = stat.AvgDelay / float64(stat.RevcPk)		
+	} else {
+		stat.AvgDelay = 0.0
+	}
 	seelog.Debug("[func:IcmpPing] Finish Addr:", t.Addr, " MaxDelay:", stat.MaxDelay, " MinDelay:", stat.MinDelay, " AvgDelay:", stat.AvgDelay, " Revc:", stat.RevcPk, " LossPK:", stat.LossPk)
 	StoragePing(stat, t)
 	wg.Done()

--- a/src/funcs/ping.go
+++ b/src/funcs/ping.go
@@ -36,7 +36,7 @@ func StartPing(t g.Target, wg *sync.WaitGroup) {
 		duringtime := time.Now().UnixNano() - starttime
 		time.Sleep(time.Duration(3000*1000000-duringtime) * time.Nanosecond)
 	}
-	stat.AvgDelay = stat.AvgDelay / float64(stat.SendPk)
+	stat.AvgDelay = stat.AvgDelay / float64(stat.RevcPk)
 	seelog.Debug("[func:IcmpPing] Finish Addr:", t.Addr, " MaxDelay:", stat.MaxDelay, " MinDelay:", stat.MinDelay, " AvgDelay:", stat.AvgDelay, " Revc:", stat.RevcPk, " LossPK:", stat.LossPk)
 	StoragePing(stat, t)
 	wg.Done()


### PR DESCRIPTION
There is a AvgDelay calculation bug! When some packages were loss, 
`stat.AvgDelay = stat.AvgDelay / float64(stat.SendPk)` is not correct. It should be `stat.AvgDelay = stat.AvgDelay / float64(stat.RevcPk)`.

平均时延的计算应该是：总时延 / 收到的包个数。