### PR TITLE
修改ping函数的循环逻辑和变量名

### DIFF
--- a/src/funcs/mapping.go
+++ b/src/funcs/mapping.go
@@ -57,7 +57,7 @@ func MappingTask(tel string, prov string, ips []string, wg *sync.WaitGroup) {
 					if stat.MinDelay == -1 || stat.MinDelay > delay {
 						stat.MinDelay = delay
 					}
-					stat.RevcPk = stat.RevcPk + 1
+					stat.RecvPk = stat.RecvPk + 1
 					seelog.Debug("[func:StartChinaMapPing IcmpPing] ID:", i, " IP:", ip)
 				} else {
 					seelog.Debug("[func:StartChinaMapPing IcmpPing] ID:", i, " IP:", ip, " | ", err)
@@ -65,8 +65,8 @@ func MappingTask(tel string, prov string, ips []string, wg *sync.WaitGroup) {
 				}
 				stat.SendPk = stat.SendPk + 1
 				stat.LossPk = int((float64(stat.LossPk) / float64(stat.SendPk)) * 100)
-				if stat.RevcPk > 0 {
-					stat.AvgDelay = stat.AvgDelay / float64(stat.RevcPk)
+				if stat.RecvPk > 0 {
+					stat.AvgDelay = stat.AvgDelay / float64(stat.RecvPk)
 				} else {
 					stat.AvgDelay = 2000
 				}
@@ -78,7 +78,7 @@ func MappingTask(tel string, prov string, ips []string, wg *sync.WaitGroup) {
 			stat.MinDelay = 2000.00
 			stat.MaxDelay = 2000.00
 			stat.SendPk = 0
-			stat.RevcPk = 0
+			stat.RecvPk = 0
 			stat.LossPk = 100
 			statMap = append(statMap, stat)
 		}
@@ -97,8 +97,8 @@ func MappingTask(tel string, prov string, ips []string, wg *sync.WaitGroup) {
 		fStatDetail.MinDelay = fStatDetail.MinDelay + stat.MinDelay
 		fStatDetail.AvgDelay = fStatDetail.AvgDelay + stat.AvgDelay
 		fStatDetail.SendPk = fStatDetail.SendPk + stat.SendPk
-		fStatDetail.RevcPk = fStatDetail.RevcPk + stat.RevcPk
-		fStatDetail.LossPk = fStatDetail.SendPk - fStatDetail.RevcPk
+		fStatDetail.RecvPk = fStatDetail.RecvPk + stat.RecvPk
+		fStatDetail.LossPk = fStatDetail.SendPk - fStatDetail.RecvPk
 		effCnt = effCnt + 1
 	}
 	gMapVal := g.MapVal{}

--- a/src/funcs/ping.go
+++ b/src/funcs/ping.go
@@ -59,6 +59,7 @@ func PingTask(t g.NetworkMember, wg *sync.WaitGroup) {
 		} else {
 			stat.AvgDelay = 0.0
 		}
+
 		stat.LossPk = int((float64(lossPK) / float64(stat.SendPk)) * 100)
 		seelog.Debug("[func:IcmpPing] Finish Addr:", t.Addr, " MaxDelay:", stat.MaxDelay, " MinDelay:", stat.MinDelay, " AvgDelay:", stat.AvgDelay, " Recv:", stat.RecvPk, " LossPK:", stat.LossPk)
 	} else {

--- a/src/funcs/ping.go
+++ b/src/funcs/ping.go
@@ -3,6 +3,7 @@ package funcs
 import (
 	"github.com/cihub/seelog"
 	_ "github.com/mattn/go-sqlite3"
+
 	"github.com/smartping/smartping/src/g"
 	"github.com/smartping/smartping/src/nettools"
 	"net"
@@ -25,6 +26,8 @@ func Ping() {
 func PingTask(t g.NetworkMember, wg *sync.WaitGroup) {
 	seelog.Info("Start Ping " + t.Addr + "..")
 	stat := g.PingSt{}
+
+
 	stat.MinDelay = -1
 	lossPK := 0
 	ipaddr, err := net.ResolveIPAddr("ip", t.Addr)
@@ -40,29 +43,30 @@ func PingTask(t g.NetworkMember, wg *sync.WaitGroup) {
 				if stat.MinDelay == -1 || stat.MinDelay > delay {
 					stat.MinDelay = delay
 				}
-				stat.RevcPk = stat.RevcPk + 1
+
+				stat.RecvPk = stat.RecvPk + 1
 				seelog.Debug("[func:StartPing IcmpPing] ID:", i, " IP:", t.Addr)
 			} else {
 				seelog.Debug("[func:StartPing IcmpPing] ID:", i, " IP:", t.Addr, "| err:", err)
 				lossPK = lossPK + 1
 			}
 			stat.SendPk = stat.SendPk + 1
-			stat.LossPk = int((float64(lossPK) / float64(stat.SendPk)) * 100)
 			duringtime := time.Now().UnixNano() - starttime
 			time.Sleep(time.Duration(3000*1000000-duringtime) * time.Nanosecond)
 		}
-		if stat.RevcPk > 0 {
-			stat.AvgDelay = stat.AvgDelay / float64(stat.RevcPk)
+		if stat.RecvPk > 0 {
+			stat.AvgDelay = stat.AvgDelay / float64(stat.RecvPk)
 		} else {
 			stat.AvgDelay = 0.0
 		}
-		seelog.Debug("[func:IcmpPing] Finish Addr:", t.Addr, " MaxDelay:", stat.MaxDelay, " MinDelay:", stat.MinDelay, " AvgDelay:", stat.AvgDelay, " Revc:", stat.RevcPk, " LossPK:", stat.LossPk)
+		stat.LossPk = int((float64(lossPK) / float64(stat.SendPk)) * 100)
+		seelog.Debug("[func:IcmpPing] Finish Addr:", t.Addr, " MaxDelay:", stat.MaxDelay, " MinDelay:", stat.MinDelay, " AvgDelay:", stat.AvgDelay, " Recv:", stat.RecvPk, " LossPK:", stat.LossPk)
 	} else {
 		stat.AvgDelay = 0.00
 		stat.MinDelay = 0.00
 		stat.MaxDelay = 0.00
 		stat.SendPk = 0
-		stat.RevcPk = 0
+		stat.RecvPk = 0
 		stat.LossPk = 100
 		seelog.Debug("[func:IcmpPing] Finish Addr:", t.Addr, " Unable to resolve destination host")
 	}
@@ -75,7 +79,7 @@ func PingTask(t g.NetworkMember, wg *sync.WaitGroup) {
 func PingStorage(pingres g.PingSt, Addr string) {
 	logtime := time.Now().Format("2006-01-02 15:04")
 	seelog.Info("[func:StartPing] ", "(", logtime, ")Starting PingStorage ", Addr)
-	sql := "INSERT INTO [pinglog] (logtime, target, maxdelay, mindelay, avgdelay, sendpk, revcpk, losspk) values('" + logtime + "','" + Addr + "','" + strconv.FormatFloat(pingres.MaxDelay, 'f', 2, 64) + "','" + strconv.FormatFloat(pingres.MinDelay, 'f', 2, 64) + "','" + strconv.FormatFloat(pingres.AvgDelay, 'f', 2, 64) + "','" + strconv.Itoa(pingres.SendPk) + "','" + strconv.Itoa(pingres.RevcPk) + "','" + strconv.Itoa(pingres.LossPk) + "')"
+	sql := "INSERT INTO [pinglog] (logtime, target, maxdelay, mindelay, avgdelay, sendpk, recvpk, losspk) values('" + logtime + "','" + Addr + "','" + strconv.FormatFloat(pingres.MaxDelay, 'f', 2, 64) + "','" + strconv.FormatFloat(pingres.MinDelay, 'f', 2, 64) + "','" + strconv.FormatFloat(pingres.AvgDelay, 'f', 2, 64) + "','" + strconv.Itoa(pingres.SendPk) + "','" + strconv.Itoa(pingres.RecvPk) + "','" + strconv.Itoa(pingres.LossPk) + "')"
 	seelog.Debug("[func:StartPing] ", sql)
 	g.DLock.Lock()
 	_, err := g.Db.Exec(sql)

--- a/src/g/struct.go
+++ b/src/g/struct.go
@@ -28,7 +28,7 @@ type NetworkMember struct {
 //Ping Struct
 type PingSt struct {
 	SendPk   int
-	RevcPk   int
+	RecvPk   int
 	LossPk   int
 	MinDelay float64
 	AvgDelay float64

--- a/src/g/struct.go
+++ b/src/g/struct.go
@@ -42,15 +42,6 @@ type PingStMini struct {
 	AvgDelay  []string `json:"avgdelay"`
 }
 
-type TcpingSt struct {
-	SendPk		int
-	RecvPk 		int // send package successfully
-	LossPk		int
-	MinDelay	float64
-	AvgDelay	float64
-	MaxDelay	float64
-}
-
 type PingLog struct {
 	Logtime  string
 	Maxdelay string

--- a/src/g/struct.go
+++ b/src/g/struct.go
@@ -42,6 +42,15 @@ type PingStMini struct {
 	AvgDelay  []string `json:"avgdelay"`
 }
 
+type TcpingSt struct {
+	SendPk		int
+	RecvPk 		int // send package successfully
+	LossPk		int
+	MinDelay	float64
+	AvgDelay	float64
+	MaxDelay	float64
+}
+
 type PingLog struct {
 	Logtime  string
 	Maxdelay string

--- a/src/http/api.go
+++ b/src/http/api.go
@@ -329,7 +329,7 @@ func configApiRoutes() {
 					if preout.Ping.MinDelay == -1 || preout.Ping.MinDelay > delay {
 						preout.Ping.MinDelay = delay
 					}
-					preout.Ping.RevcPk = preout.Ping.RevcPk + 1
+					preout.Ping.RecvPk = preout.Ping.RecvPk + 1
 				} else {
 					lossPK = lossPK + 1
 				}
@@ -337,8 +337,8 @@ func configApiRoutes() {
 				preout.Ping.LossPk = int((float64(lossPK) / float64(preout.Ping.SendPk)) * 100)
 			}
 		}
-		if preout.Ping.RevcPk > 0 {
-			preout.Ping.AvgDelay = preout.Ping.AvgDelay / float64(preout.Ping.RevcPk)
+		if preout.Ping.RecvPk > 0 {
+			preout.Ping.AvgDelay = preout.Ping.AvgDelay / float64(preout.Ping.RecvPk)
 		} else {
 			preout.Ping.AvgDelay = 3000
 			preout.Ping.MinDelay = 3000


### PR DESCRIPTION
1.funcs/ping.go文件中计算stat.LossPk的语句放在循环外面更合理一点，不然每次循环都要计算一次。
2.变量RevcPk名称改成RecvPk